### PR TITLE
Transaction Matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ go-defi
 
 # regex
 **/*.db
+abifile.txt
+
+outfile.txt

--- a/README.md
+++ b/README.md
@@ -59,3 +59,11 @@ Provides a wrapper around the SimulatedBackend allowing for an in-memory blockch
 ## utils
 
 Provides utility functions including all [goethereum book utils](https://goethereumbook.org/en/util-go/), a helper to make `bind.TransactOpts` safe for concurrent use, as well as a general `Blockchain` interface that satisfies all functions provided by simulated backend, as well as `ethclient` which is useful for drop-in replacement of actual RPC clients, and test environments.
+
+# examples
+
+## transaction matching
+
+```shell
+$> /go-defi txm --methods transfer --methods transferFrom --methods buy --contract.address 0x5ade7aE8660293F2ebfcEfaba91d141d72d221e8
+```

--- a/bclient/bclient.go
+++ b/bclient/bclient.go
@@ -24,7 +24,6 @@ type BClient struct {
 // types are exposed in addition to helper functions
 func NewClient(ctx context.Context, bc utils.Blockchain) (*BClient, error) {
 	ctx, cancel := context.WithCancel(ctx)
-
 	return &BClient{
 		ctx:    ctx,
 		cancel: cancel,

--- a/bclient/bclient.go
+++ b/bclient/bclient.go
@@ -2,6 +2,7 @@ package bclient
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/bonedaddy/go-defi/sushiswap"
 	"github.com/bonedaddy/go-defi/uniswap"
@@ -53,6 +54,23 @@ func (bc *BClient) EthClient() (*ethclient.Client, error) {
 		return nil, ErrNotEthClient
 	}
 	return ec, nil
+}
+
+// ChainID performs a best effort at determining the chainid
+// we do this by first attempting to retrieve the id from
+// a simulated backend, and if that fails get the chain id
+// from an ethclient
+func (bc *BClient) ChainID() (*big.Int, error) {
+	if sb, err := bc.SimulatedBackend(); err == nil {
+		// get chainid
+		return sb.Blockchain().Config().ChainID, nil
+	} else {
+		if ec, err := bc.EthClient(); err != nil {
+			return nil, err
+		} else {
+			return ec.ChainID(bc.ctx)
+		}
+	}
 }
 
 // Blockchain returns the underlying blockchain interface

--- a/bclient/bclient.go
+++ b/bclient/bclient.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bonedaddy/go-defi/sushiswap"
 	"github.com/bonedaddy/go-defi/uniswap"
 	"github.com/bonedaddy/go-defi/utils"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
@@ -33,6 +34,17 @@ func NewClient(ctx context.Context, bc utils.Blockchain) (*BClient, error) {
 	}, nil
 }
 
+// SimulatedBackend attempts to conver the Blockchain interface to a simulated backend type
+// returning an error if unable to type convert the interface. This likely indicates
+// that an ethclient backend is being used
+func (bc *BClient) SimulatedBackend() (*backends.SimulatedBackend, error) {
+	sn, ok := bc.bc.(*backends.SimulatedBackend)
+	if !ok {
+		return nil, ErrNotSimulatedBackend
+	}
+	return sn, nil
+}
+
 // EthClient attempts to conver the Blockchain interface to an ethclient type
 // returning an error if unable to type convert the interface. This likely indicates
 // that a simulated backend is being used
@@ -43,6 +55,9 @@ func (bc *BClient) EthClient() (*ethclient.Client, error) {
 	}
 	return ec, nil
 }
+
+// Blockchain returns the underlying blockchain interface
+func (bc *BClient) Blockchain() utils.Blockchain { return bc.bc }
 
 // CurrentBlock returns the current block known by the ethereum client
 func (bc *BClient) CurrentBlock() (uint64, error) {

--- a/bclient/errors.go
+++ b/bclient/errors.go
@@ -7,4 +7,8 @@ var (
 	// blockchain interface to an ethclient, when the underlying blockchain interface is not
 	// an ethclient type. Usually will be encountered when using a simulated backend
 	ErrNotEthClient = errors.New("underlying blockchain provider is not of type ethclient.Client")
+	// ErrNotSimulatedBackend is an error returned when attempting to do type conversions against the
+	// blockchain interface to a simulated backend, when the underlying blockchain interface is not
+	// a simulated backend type. Usually will be encountered when using an ethclient backend
+	ErrNotSimulatedBackend = errors.New("underlying blockchain provider is not of type simulated backend")
 )

--- a/bclient/transactions.go
+++ b/bclient/transactions.go
@@ -1,0 +1,21 @@
+package bclient
+
+import (
+	"encoding/hex"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// EncodeTx is used to marshal a transaction and hex encode it
+// suitable for encoding transctions and storing them into a database
+func (bc *BClient) EncodeTx(hash string) (string, error) {
+	tx, _, err := bc.bc.TransactionByHash(bc.ctx, common.HexToHash(hash))
+	if err != nil {
+		return "", err
+	}
+	txBinary, err := tx.MarshalBinary()
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(txBinary), nil
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -9,7 +9,7 @@ func New(name, usage, version string) *cli.App {
 	app.Name = name
 	app.Usage = usage
 	app.Version = version
-	app.Commands = cli.Commands{configCommand(), txMatchCommand()}
+	app.Commands = cli.Commands{configCommand(), txMatchCommand(), transactionsCommand()}
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:    "config.path",

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -9,7 +9,7 @@ func New(name, usage, version string) *cli.App {
 	app.Name = name
 	app.Usage = usage
 	app.Version = version
-	app.Commands = cli.Commands{configCommand()}
+	app.Commands = cli.Commands{configCommand(), txMatchCommand()}
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:    "config.path",

--- a/cli/transactions_command.go
+++ b/cli/transactions_command.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bonedaddy/go-defi/bclient"
+	"github.com/bonedaddy/go-defi/config"
+	"github.com/urfave/cli/v2"
+)
+
+func transactionsCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "transactions",
+		Aliases: []string{"txs"},
+		Usage:   "command for workign with transactions",
+		Subcommands: cli.Commands{
+			&cli.Command{
+				Name:    "encode",
+				Aliases: []string{"enc"},
+				Usage:   "hex encoded transaction binary representation",
+				Action: func(c *cli.Context) error {
+					ctx, cancel := context.WithCancel(c.Context)
+					defer cancel()
+					cfg, err := config.LoadConfig(c.String("config.path"))
+					if err != nil {
+						return err
+					}
+					client, err := cfg.EthClient(ctx)
+					if err != nil {
+						return err
+					}
+					bc, err := bclient.NewClient(ctx, client)
+					if err != nil {
+						return err
+					}
+					enc, err := bc.EncodeTx(c.String("tx.hash"))
+					if err != nil {
+						return err
+					}
+					fmt.Println(enc)
+					return nil
+				},
+			},
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "tx.hash",
+				Value: "",
+				Usage: "hash of the transaction to work with",
+			},
+		},
+	}
+}

--- a/cli/txmatch_command.go
+++ b/cli/txmatch_command.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"context"
+	"io/ioutil"
+
+	"github.com/bonedaddy/go-defi/bclient"
+	"github.com/bonedaddy/go-defi/config"
+	"github.com/bonedaddy/go-defi/txmatch"
+	"github.com/urfave/cli/v2"
+)
+
+func txMatchCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "txmatch",
+		Aliases: []string{"txm"},
+		Usage:   "allows filtering for transactions that match predefined conditions",
+		Action: func(c *cli.Context) error {
+			ctx, cancel := context.WithCancel(c.Context)
+			defer cancel()
+			cfg, err := config.LoadConfig(c.String("config.path"))
+			if err != nil {
+				return err
+			}
+			client, err := cfg.EthClient(ctx)
+			if err != nil {
+				return err
+			}
+			abiBytes, err := ioutil.ReadFile(c.String("abi.file"))
+			if err != nil {
+				return err
+			}
+			bc, err := bclient.NewClient(ctx, client)
+			if err != nil {
+				return err
+			}
+			matcher, err := txmatch.NewMatcher(
+				bc,
+				string(abiBytes),
+				[]string{c.String("method")},
+				[]string{c.String("contract.address")},
+			)
+			if err != nil {
+				return err
+			}
+			return matcher.Match(c.Uint64("start.block"), c.Uint64("end.block"))
+		},
+		Flags: []cli.Flag{
+			&cli.Uint64Flag{
+				Name:  "start.block",
+				Value: 0,
+				Usage: "start of the block range to query",
+			},
+			&cli.Uint64Flag{
+				Name:  "end.block",
+				Value: 0,
+				Usage: "end of the block range to query",
+			},
+			&cli.StringFlag{
+				Name:  "contract.address",
+				Value: "",
+				Usage: "contract address to filter transactions against",
+			},
+			&cli.StringFlag{
+				Name:  "method",
+				Usage: "method to filter transactions against",
+			},
+			&cli.StringFlag{
+				Name:  "abi.file",
+				Usage: "file containing the abi definition",
+			},
+		},
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -165,17 +165,16 @@ func NewConfig(path string) error {
 // however if loading from path fails, we attempt to load
 // from environment variabels
 func LoadConfig(path string) (cfg *Config, err error) {
+	cfg = new(Config)
 	func() {
 		var r []byte
 		r, err = ioutil.ReadFile(path)
 		if err != nil {
 			return
 		}
-		var _cfg Config
-		if err := yaml.Unmarshal(r, &cfg); err != nil {
+		if err := yaml.Unmarshal(r, cfg); err != nil {
 			return
 		}
-		cfg = &_cfg
 	}()
 	if err != nil {
 		cfg = &Config{}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,19 @@ module github.com/bonedaddy/go-defi
 go 1.15
 
 require (
-	github.com/ethereum/go-ethereum v1.10.1
+	github.com/consensys/gurvy v0.3.8 // indirect
+	github.com/edsrzf/mmap-go v1.0.0 // indirect
+	github.com/ethereum/go-ethereum v1.10.0
+	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/google/uuid v1.1.5 // indirect
+	github.com/graph-gophers/graphql-go v0.0.0-20201113091052-beb923fada29 // indirect
+	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
+	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
+	github.com/huin/goupnp v1.0.1-0.20200620063722-49508fba0031 // indirect
+	github.com/influxdata/influxdb v1.8.3 // indirect
 	github.com/ipfs/go-ipfs-config v0.12.0
+	github.com/rs/cors v1.7.0 // indirect
 	github.com/shopspring/decimal v1.2.0
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,7 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
+github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847 h1:rtI0fD4oG/8eVokGVPYJEW1F88p1ZNgXiEIs9thEE4A=
 github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847/go.mod h1:D/tb0zPVXnP7fmsLZjtdUhSsumbK/ij54UXjjVgMGxQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -133,7 +134,10 @@ github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/ethereum/go-ethereum v1.9.25 h1:mMiw/zOOtCLdGLWfcekua0qPrJTe7FVIiHJ4IKNTfR0=
 github.com/ethereum/go-ethereum v1.9.25/go.mod h1:vMkFiYLHI4tgPw4k2j4MHKoovchFE8plZ0M9VMk4/oM=
+github.com/ethereum/go-ethereum v1.10.0 h1:EBZuZYjk1DHboBJb2YkBN8xItELRY6mtZEiYJKuH0+M=
+github.com/ethereum/go-ethereum v1.10.0/go.mod h1:E5e/zvdfUVr91JZ0AwjyuJM3x+no51zZJRz61orLLSk=
 github.com/ethereum/go-ethereum v1.10.1 h1:bGQezu+kqqRBczcSAruEoqVzTjtkeDnUGI2I4uroyUE=
 github.com/ethereum/go-ethereum v1.10.1/go.mod h1:E5e/zvdfUVr91JZ0AwjyuJM3x+no51zZJRz61orLLSk=
 github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5/go.mod h1:JpoxHjuQauoxiFMl1ie8Xc/7TfLuMZ5eOCONd1sUBHg=
@@ -675,6 +679,7 @@ github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsq
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
+github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222 h1:goeTyGkArOZIVOMA0dQbyuPWGNQJZGPwPu/QS9GlpnA=
 github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
@@ -760,7 +765,9 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4 h1:Gb2Tyox57NRNuZ2d3rmvB3pcmbu7O1RS3m8WRx7ilrg=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
+github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570 h1:gIlAHnH1vJb5vwEjIp5kBj/eu99p/bl0Ay2goiPe5xE=
 github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570/go.mod h1:8OR4w3TdeIHIh1g6EMY5p0gVNOovcWC+1vpc7naMuAw=
+github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 h1:njlZPzLwU639dk2kqnCPPv+wNjq7Xb6EfUxe/oX0/NM=
 github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3/go.mod h1:hpGUWaI9xL8pRQCTXQgocU38Qw1g0Us7n5PxxTwTCYU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -800,6 +807,7 @@ github.com/whyrusleeping/mafmt v1.2.8/go.mod h1:faQJFPbLSxzD9xpA02ttW/tS9vZykNvX
 github.com/whyrusleeping/mdns v0.0.0-20180901202407-ef14215e6b30/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
+github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208 h1:1cngl9mPEoITZG8s8cVcUy5CeIBYhEESkOB7m6Gmkrk=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/txmatch/doc.go
+++ b/txmatch/doc.go
@@ -1,0 +1,2 @@
+// Package txmatch provides a flexible method of filtering transactions to check for ones matching a particular abi method
+package txmatch

--- a/txmatch/txmatch.go
+++ b/txmatch/txmatch.go
@@ -79,7 +79,7 @@ func (m *Matcher) Match(outFile string, startBlock, endBlock uint64) error {
 		block, err := ec.BlockByNumber(m.bc.Context(), ib)
 		if err != nil {
 			m.l.Error("ecountered error fetching block by number", zap.Error(err), zap.Uint64("block.number", i))
-			continue
+			return err
 		}
 		for _, tx := range block.Transactions() {
 			if utils.LogContextDone(m.l, m.bc.Context()) {

--- a/txmatch/txmatch.go
+++ b/txmatch/txmatch.go
@@ -99,9 +99,9 @@ func (m *Matcher) Match(outFile string, startBlock, endBlock uint64) error {
 			// for some reason when using common.Address in a map
 			// the al zero adddress will be marked as true
 			// and pass the check above m.wantContracts so explicitly ignore it
-			if tx.To().String() == common.HexToAddress("").String() {
-				continue
-			}
+			// if tx.To().String() == common.HexToAddress("").String() {
+			//	continue
+			//}
 			if len(tx.Data()) < 3 {
 				// skip as this is not a contract call we are interested in
 				continue

--- a/txmatch/txmatch.go
+++ b/txmatch/txmatch.go
@@ -1,0 +1,70 @@
+package txmatch
+
+import (
+	"log"
+	"math/big"
+	"strings"
+
+	"github.com/bonedaddy/go-defi/bclient"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type Matcher struct {
+	bc            *bclient.BClient
+	wantMethods   map[string]bool
+	wantContracts map[common.Address]bool
+	abi           abi.ABI
+}
+
+// NewMatcher returns a new transaction matcher
+func NewMatcher(bc *bclient.BClient, abistr string, methods, contracts []string) (*Matcher, error) {
+	parsedABI, err := abi.JSON(strings.NewReader(abistr))
+	if err != nil {
+		return nil, err
+	}
+	var (
+		wantMethods   = make(map[string]bool)
+		wantContracts = make(map[common.Address]bool)
+	)
+	for _, method := range methods {
+		wantMethods[method] = true
+	}
+	for _, contract := range contracts {
+		wantContracts[common.HexToAddress(contract)] = true
+	}
+	return &Matcher{
+		abi:           parsedABI,
+		bc:            bc,
+		wantMethods:   wantMethods,
+		wantContracts: wantContracts,
+	}, nil
+}
+
+func (m *Matcher) Match(startBlock, endBlock uint64) error {
+	ec, err := m.bc.EthClient()
+	if err != nil {
+		return err
+	}
+	for i := startBlock; i <= endBlock; i++ {
+		ib := new(big.Int).SetUint64(i)
+		block, err := ec.BlockByNumber(m.bc.Context(), ib)
+		if err != nil {
+			log.Println("encountered error fetching block by number: ", block)
+			continue
+		}
+		for _, tx := range block.Transactions() {
+			// first check it is to one of the contracts
+			if tx.To() == nil {
+				// skip this as its a contract deployment transaction
+				continue
+			}
+			if !m.wantContracts[*tx.To()] {
+				// skip this as its not to a contract we are interested in
+				continue
+			}
+			log.Println("found interested transaction: ", tx.Hash())
+		}
+	}
+	return nil
+}

--- a/txmatch/txmatch.go
+++ b/txmatch/txmatch.go
@@ -3,11 +3,14 @@ package txmatch
 import (
 	"log"
 	"math/big"
+	"os"
 	"strings"
 
 	"github.com/bonedaddy/go-defi/bclient"
+	"github.com/bonedaddy/go-defi/utils"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type Matcher struct {
@@ -41,12 +44,25 @@ func NewMatcher(bc *bclient.BClient, abistr string, methods, contracts []string)
 	}, nil
 }
 
-func (m *Matcher) Match(startBlock, endBlock uint64) error {
+func (m *Matcher) Match(outFile string, startBlock, endBlock uint64) error {
+	fh, err := os.Create(outFile)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+	chid, err := m.bc.ChainID()
+	if err != nil {
+		return err
+	}
 	ec, err := m.bc.EthClient()
 	if err != nil {
 		return err
 	}
 	for i := startBlock; i <= endBlock; i++ {
+		if utils.ContextDone(m.bc.Context()) {
+			log.Println("context cancelled, exiting")
+			return nil
+		}
 		ib := new(big.Int).SetUint64(i)
 		block, err := ec.BlockByNumber(m.bc.Context(), ib)
 		if err != nil {
@@ -54,16 +70,41 @@ func (m *Matcher) Match(startBlock, endBlock uint64) error {
 			continue
 		}
 		for _, tx := range block.Transactions() {
+			if utils.ContextDone(m.bc.Context()) {
+				log.Println("context cancelled, exiting")
+				return nil
+			}
 			// first check it is to one of the contracts
 			if tx.To() == nil {
 				// skip this as its a contract deployment transaction
 				continue
 			}
+			// validate it is to an interested contract
 			if !m.wantContracts[*tx.To()] {
 				// skip this as its not to a contract we are interested in
 				continue
 			}
 			log.Println("found interested transaction: ", tx.Hash())
+			// validate the method is as expected
+			method, err := m.abi.MethodById(tx.Data()[0:4])
+			if err != nil {
+				// skip it
+				continue
+			}
+			if !m.wantMethods[method.Name] {
+				log.Println("Invalid method name")
+				// skip
+				continue
+			}
+			msg, err := tx.AsMessage(types.NewEIP2930Signer(chid))
+			if err != nil {
+				log.Println("failed to parse tx as message: ", err)
+				continue
+			}
+			_, err = fh.WriteString(msg.From().String() + "\n")
+			if err != nil {
+				log.Println("failed to append address to file: ", err)
+			}
 		}
 	}
 	return nil

--- a/txmatch/txmatch_test.go
+++ b/txmatch/txmatch_test.go
@@ -1,0 +1,51 @@
+package txmatch
+
+import (
+	"context"
+	"encoding/hex"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bonedaddy/go-defi/bclient"
+	"github.com/bonedaddy/go-defi/bindings/erc20"
+	"github.com/bonedaddy/go-defi/config"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+
+	// NOTE: these transactions and addresses dont imply anything about fitness or correctness of the contracts
+	// they are simply here for testing purposes. dont interact with any contracts included unless thoroughly researched
+	// encodedTx is a hex encoded marshalled transaction
+	encodedTx    = "f8aa04851d91ca360083012d08945ade7ae8660293f2ebfcefaba91d141d72d221e880b844a9059cbb0000000000000000000000001cdb2c26a767ba197fdbbd9fa3488a6032811a7b00000000000000000000000000000000000000000001a84079ae6836e61e8e6625a0c488c44dcd992a3aa9dd9d3e9211b4cd55132c226fe6f743c729a07671a917c5a00ca637f1e43190a2bdff3dbdeec4d2151bf4941a3b4826daca28cdb0a7087499"
+	contractAddr = "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8"
+)
+
+func TestTxMatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_cfg := *config.ExampleConfig
+	cfg := &_cfg
+	cfg.ProviderType = "infura"
+	cfg.APIKey = os.Getenv("INFURA_API_KEY")
+	ec, err := cfg.EthClient(ctx)
+	require.NoError(t, err)
+	bc, err := bclient.NewClient(ctx, ec)
+	require.NoError(t, err)
+	parsedABI, err := abi.JSON(strings.NewReader(erc20.Erc20ABI))
+	require.NoError(t, err)
+	decodedTx, err := hex.DecodeString(encodedTx)
+	require.NoError(t, err)
+	tx := new(types.Transaction)
+	require.NoError(t, tx.UnmarshalBinary(decodedTx))
+	_ = parsedABI
+	wantMethods := []string{"transfer", "transferFrom"}
+	matcher, err := NewMatcher(bc, erc20.Erc20ABI, wantMethods, []string{contractAddr})
+	require.NoError(t, err)
+	startBlock := uint64(12082591)
+	endBlock := uint64(12082599)
+	matcher.Match(startBlock, endBlock)
+}

--- a/txmatch/txmatch_test.go
+++ b/txmatch/txmatch_test.go
@@ -33,6 +33,8 @@ func TestTxMatch(t *testing.T) {
 	cfg := &_cfg
 	cfg.ProviderType = "infura"
 	cfg.APIKey = os.Getenv("INFURA_API_KEY")
+	logger, err := cfg.ZapLogger()
+	require.NoError(t, err)
 	ec, err := cfg.EthClient(ctx)
 	require.NoError(t, err)
 	bc, err := bclient.NewClient(ctx, ec)
@@ -45,7 +47,7 @@ func TestTxMatch(t *testing.T) {
 	require.NoError(t, tx.UnmarshalBinary(decodedTx))
 	_ = parsedABI
 	wantMethods := []string{"transfer", "transferFrom"}
-	matcher, err := NewMatcher(bc, erc20.Erc20ABI, wantMethods, []string{contractAddr})
+	matcher, err := NewMatcher(logger, bc, erc20.Erc20ABI, wantMethods, []string{contractAddr})
 	require.NoError(t, err)
 	startBlock := uint64(12082591)
 	endBlock := uint64(12082599)

--- a/txmatch/txmatch_test.go
+++ b/txmatch/txmatch_test.go
@@ -3,6 +3,7 @@ package txmatch
 import (
 	"context"
 	"encoding/hex"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -25,6 +26,7 @@ var (
 )
 
 func TestTxMatch(t *testing.T) {
+	t.Cleanup(func() { os.Remove("wantfile.txt") })
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	_cfg := *config.ExampleConfig
@@ -47,5 +49,8 @@ func TestTxMatch(t *testing.T) {
 	require.NoError(t, err)
 	startBlock := uint64(12082591)
 	endBlock := uint64(12082599)
-	matcher.Match(startBlock, endBlock)
+	require.NoError(t, matcher.Match("wantfile.txt", startBlock, endBlock))
+	data, err := ioutil.ReadFile("wantfile.txt")
+	require.NoError(t, err)
+	require.Equal(t, string(data), "0xA96F2A820D3d7d5Df3C6c638d40C295a0CF255D1\n")
 }

--- a/utils/blockchain.go
+++ b/utils/blockchain.go
@@ -46,4 +46,6 @@ type Blockchain interface {
 	// a subscription immediately, which can be used to stream the found events.
 	SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error)
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
+	// SubscribeNewHead returns an event subscription for a new header.
+	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
 }

--- a/utils/blockchain.go
+++ b/utils/blockchain.go
@@ -48,4 +48,9 @@ type Blockchain interface {
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 	// SubscribeNewHead returns an event subscription for a new header.
 	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
+	// TransactionByHash checks the pool of pending transactions in addition to the
+	// blockchain. The isPending return value indicates whether the transaction has been
+	// mined yet. Note that the transaction may not be part of the canonical chain even if
+	// it's not pending.
+	TransactionByHash(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error)
 }

--- a/utils/context.go
+++ b/utils/context.go
@@ -1,0 +1,13 @@
+package utils
+
+import "context"
+
+// ContextDone returns true if we can exit due to a cancelled context.
+func ContextDone(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
+}

--- a/utils/context.go
+++ b/utils/context.go
@@ -1,6 +1,10 @@
 package utils
 
-import "context"
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
 
 // ContextDone returns true if we can exit due to a cancelled context.
 func ContextDone(ctx context.Context) bool {
@@ -8,6 +12,16 @@ func ContextDone(ctx context.Context) bool {
 	case <-ctx.Done():
 		return true
 	default:
+		return false
+	}
+}
+
+// LogContextDone is like ContextDone but logs when the context is done
+func LogContextDone(logger *zap.Logger, ctx context.Context) bool {
+	if ContextDone(ctx) {
+		logger.Info("context cancelled")
+		return true
+	} else {
 		return false
 	}
 }


### PR DESCRIPTION
Adds the ability to filter transactions to particular contract addresses and ABIs. This can be used to filter out all addresses that interacted with a particular contract using particular ABI methods. For example given an ERC20 contract and a range of blocks, you can find all addresses that invoked transfer, transferFrom, and approval methods within the specified block range.

This also fixes a bug with incorrectly loading configuration file from disk.